### PR TITLE
Hue API Request Randomization

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,12 +130,16 @@ class DmxHue {
 
     const dmx = dmxData.slice(address, address + (3 * options.lights.length));
     let j = 0;
+    const length = options.lights.length;
+    let indices = Array.from({length}, (_, i) => i);
+    indices = this._shuffle(indices);
 
-    for (let i = 0; i < options.lights.length; i++) {
+    let i;
+    for (i of indices) {
       const lightId = options.lights[i].id;
+      j = i * 3;
       const color = dmx.slice(j, j + 3);
       const previous = options.colors[lightId];
-      j += 3;
 
       // Update light only if color changed
       if (!previous || color[0] !== previous[0] || color[1] !== previous[1] || color[2] !== previous[2]) {
@@ -224,6 +228,26 @@ class DmxHue {
             console.log(`Configuration saved at ${chalk.green(Util.config.path)}`);
           });
       });
+  }
+
+  _shuffle(array) {
+    let currentIndex = array.length;
+    let temporaryValue;
+    let randomIndex;
+
+    // While there remain elements to shuffle...
+    while (currentIndex !== 0) {
+      // Pick a remaining element...
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+
+      // And swap it with the current element.
+      temporaryValue = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temporaryValue;
+    }
+
+    return array;
   }
 
   run() {


### PR DESCRIPTION
While using dmx-hue with SoundSwitch (DJ Lighting software), I noticed that for my set of Hue lights the first light in the list was being updated quite frequently, while other lights in the set were not.

I noticed that the code loops over every light by index, and issues a Hue API request to update that light.  

Due to the nature of the bridge being unable to update frequently, this results in the first light being treated with priority when many lights are changing at once.  

This PR creates a randomly shuffled array of light indexes for each DMX update iteration.  This allows each light in the set to have it's Hue API requests processed in a more fair manner.

There must be a more efficient way to implement this (my Javascript skills are quite lacking), but in my testing the responsiveness of the lights is much better.

This is obviously performing a O(n) (n = number of lights) randomization operation per-DMX light update, which is quite poor from an efficiency perspective.