### PR TITLE
feat: allow other ART-NET apps on same machine

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -15,7 +15,7 @@ const MIN_PROTOCOL_VERSION = 14;
 class ArtNet {
   static listen(address, dmxHandler) {
     // Set up the socket
-    const socket = dgram.createSocket('udp4', (msg, peer) => {
+    const socket = dgram.createSocket({type: 'udp4', reuseAddr: true}, (msg, peer) => {
       const header = msg.toString('utf8', 0, 8);
       const opcode = msg.readUInt16LE(8);
       const version = msg.readUInt16BE(10);


### PR DESCRIPTION
By setting the "reuseAddr" option on the socket, multiple processes can bind to the UDP broadcasts on the socket. For example, I was able to connect the ChamSys MagicQ software running on the same machine once I set this.

This will probably fix #32 - I haven't got Resolume installed to try.